### PR TITLE
feat: 単発タスクのルール行作成と表示統一、およびCOUNT対応を実装\n\n- 単発タスクにも RECURRENCE_RULES 行…

### DIFF
--- a/src/ipc/taskHandlers.ts
+++ b/src/ipc/taskHandlers.ts
@@ -67,5 +67,28 @@ export function registerTaskIpcHandlers(opts: {
       throw e;
     }
   });
-}
 
+  // Occurrences
+  ipcMain.handle('occ:list', async (_event, params: { from?: string; to?: string; query?: string; status?: string } = {}) => {
+    const db = getTaskDb();
+    if (!db) return [];
+    try {
+      return await (db as any).listOccurrences(params);
+    } catch (e) {
+      log.error('occ:list error', e);
+      throw e;
+    }
+  });
+
+  ipcMain.handle('occ:complete', async (_event, id: number) => {
+    const db = getTaskDb();
+    if (!db) return { success: false };
+    try {
+      await (db as any).completeOccurrence(id);
+      return { success: true };
+    } catch (e) {
+      log.error('occ:complete error', e);
+      throw e;
+    }
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ function createMenu(): void {
       label: 'メニュー',
       submenu: [
         { label: 'Top', click: () => mainWindow?.loadFile('index.html') },
+        { label: 'タスク表示', click: () => mainWindow?.loadFile('task-view.html') },
         { label: 'タスク編集', click: () => mainWindow?.loadFile('task-editor.html') }
       ]
     }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -21,6 +21,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   createTask: (payload: any) => ipcRenderer.invoke('tasks:create', payload),
   updateTask: (id: number, payload: any) => ipcRenderer.invoke('tasks:update', id, payload),
   deleteTask: (id: number) => ipcRenderer.invoke('tasks:delete', id)
+  ,
+  // Occurrences
+  listOccurrences: (params?: any) => ipcRenderer.invoke('occ:list', params || {}),
+  completeOccurrence: (id: number) => ipcRenderer.invoke('occ:complete', id)
 });
 
 declare global {
@@ -39,6 +43,8 @@ declare global {
       createTask: (payload: any) => Promise<{ success: boolean; id?: number }>;
       updateTask: (id: number, payload: any) => Promise<{ success: boolean }>;
       deleteTask: (id: number) => Promise<{ success: boolean }>;
+      listOccurrences: (params?: any) => Promise<any[]>;
+      completeOccurrence: (id: number) => Promise<{ success: boolean }>;
     };
   }
 }

--- a/src/renderer/taskViewer.ts
+++ b/src/renderer/taskViewer.ts
@@ -1,0 +1,117 @@
+export {};
+
+type Task = {
+  ID?: number;
+  TITLE: string;
+  DESCRIPTION?: string | null;
+  STATUS: 'todo' | 'doing' | 'done' | 'archived';
+  PRIORITY?: number | null;
+  DUE_AT?: string | null;
+  START_DATE?: string | null;
+  START_TIME?: string | null;
+  IS_RECURRING?: number;
+  FREQ?: string | null;
+  MONTHLY_DAY?: number | null;
+};
+
+const el = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+
+function formatDateInput(dateStr?: string | null): string {
+  if (!dateStr) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return '';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const da = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${da}`;
+}
+
+function ymd(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const da = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${da}`;
+}
+
+function clampDay(year: number, monthIndex0: number, day: number): Date {
+  // monthIndex0: 0..11
+  const last = new Date(year, monthIndex0 + 1, 0).getDate();
+  const d = Math.min(Math.max(day, 1), last);
+  return new Date(year, monthIndex0, d);
+}
+
+function nextMonthlyDate(day: number, from: Date): string {
+  // If from day < target day -> this month, else next month
+  const y = from.getFullYear();
+  const m0 = from.getMonth();
+  const thisMonth = clampDay(y, m0, day);
+  if (thisMonth >= new Date(y, m0, from.getDate())) {
+    return ymd(thisMonth);
+  }
+  const nextMonth = (m0 + 1) % 12;
+  const nextYear = y + (m0 === 11 ? 1 : 0);
+  return ymd(clampDay(nextYear, nextMonth, day));
+}
+
+async function loadTasks(): Promise<void> {
+  const query = el<HTMLInputElement>('search').value.trim();
+  const occStatus = el<HTMLSelectElement>('statusFilter').value.trim();
+  const params: any = {};
+  if (query) params.query = query;
+  if (occStatus) params.status = occStatus;
+  // Default range: first day of this month to last day of next month
+  const now = new Date();
+  const y = now.getFullYear();
+  const m0 = now.getMonth();
+  const from = new Date(y, m0, 1);
+  const to = new Date(y, m0 + 2, 0);
+  params.from = formatDateInput(from.toISOString());
+  params.to = formatDateInput(to.toISOString());
+
+  const occs = await window.electronAPI.listOccurrences(params);
+  const list = el<HTMLDivElement>('taskList');
+  list.innerHTML = '';
+  if (!occs.length) {
+    list.innerHTML = '<div style="color:#666;">該当するオカレンスはありません。</div>';
+    return;
+  }
+  occs.forEach((o: any) => {
+    const div = document.createElement('div');
+    div.className = 'task' + (o.OCC_STATUS === 'done' ? ' done' : '');
+    const left = document.createElement('div');
+    const meta = `予定日: ${formatDateInput(o.SCHEDULED_DATE)} ・ タスク: ${o.TASK_ID} ・ 状態: ${o.OCC_STATUS}`;
+    left.innerHTML = `<div class="title">${o.TITLE || '(無題)'}</div>` +
+      `<div class="meta">${meta}</div>`;
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+    const btn = document.createElement('button');
+    if (o.OCCURRENCE_ID) {
+      if (o.OCC_STATUS !== 'done') {
+        btn.textContent = '完了にする';
+        btn.onclick = async () => {
+          await window.electronAPI.completeOccurrence(o.OCCURRENCE_ID);
+          await loadTasks();
+        };
+      } else {
+        btn.textContent = '完了済み';
+        btn.disabled = true;
+      }
+    } else {
+      // 非繰り返し（単発）タスク表示用: 完了操作は編集画面から行う
+      btn.textContent = (o.TASK_STATUS === 'done') ? '完了済み' : '単発タスク';
+      btn.disabled = true;
+    }
+    actions.appendChild(btn);
+    div.appendChild(left);
+    div.appendChild(actions);
+    list.appendChild(div);
+  });
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  el<HTMLInputElement>('search').addEventListener('input', () => loadTasks());
+  el<HTMLSelectElement>('statusFilter').addEventListener('change', () => loadTasks());
+  el<HTMLButtonElement>('refreshBtn').addEventListener('click', () => loadTasks());
+  await loadTasks();
+});

--- a/src/taskDatabase.ts
+++ b/src/taskDatabase.ts
@@ -61,6 +61,136 @@ export class TaskDatabase {
     });
   }
 
+  // ===== Occurrences (recurring instances) =====
+  private clampMonthlyDate(year: number, monthIndex0: number, day: number): string {
+    const last = new Date(year, monthIndex0 + 1, 0).getDate();
+    const d = Math.min(Math.max(day, 1), last);
+    const dt = new Date(year, monthIndex0, d);
+    const y = dt.getFullYear();
+    const m = String(dt.getMonth() + 1).padStart(2, '0');
+    const da = String(dt.getDate()).padStart(2, '0');
+    return `${y}-${m}-${da}`;
+  }
+
+  private async ensureRecurringMonthlyOccurrences(monthsAhead: number = 2): Promise<void> {
+    // Create pending occurrences for current month and next N-1 months for monthly recurring tasks.
+    const now = new Date();
+    const startYear = now.getFullYear();
+    const startMonth0 = now.getMonth();
+    const tasks = await this.all<any>(
+      `SELECT T.ID AS TASK_ID, T.START_DATE, T.START_TIME, T.STATUS, R.MONTHLY_DAY
+       FROM TASKS T
+       JOIN RECURRENCE_RULES R ON R.TASK_ID = T.ID AND R.FREQ = 'monthly'
+       WHERE T.IS_RECURRING = 1 AND (T.STATUS IS NULL OR T.STATUS != 'archived')`
+    );
+    for (const t of tasks) {
+      const monthlyDay = Number(t.MONTHLY_DAY);
+      if (!monthlyDay || isNaN(monthlyDay)) continue;
+      for (let i = 0; i < monthsAhead; i++) {
+        const m0 = (startMonth0 + i) % 12;
+        const y = startYear + Math.floor((startMonth0 + i) / 12);
+        const scheduledDate = this.clampMonthlyDate(y, m0, monthlyDay);
+        // Respect START_DATE if set and after scheduledDate => skip creation
+        if (t.START_DATE && new Date(scheduledDate) < new Date(t.START_DATE)) continue;
+        const exists = await this.get<any>(
+          `SELECT ID FROM TASK_OCCURRENCES WHERE TASK_ID = ? AND SCHEDULED_DATE = ?`,
+          [t.TASK_ID, scheduledDate]
+        );
+        if (!exists) {
+          const nowIso = this.nowIso();
+          await this.run(
+            `INSERT INTO TASK_OCCURRENCES (TASK_ID, SCHEDULED_DATE, SCHEDULED_TIME, STATUS, CREATED_AT, UPDATED_AT)
+             VALUES (?, ?, ?, 'pending', ?, ?)`,
+            [t.TASK_ID, scheduledDate, t.START_TIME || null, nowIso, nowIso]
+          );
+        }
+      }
+    }
+  }
+
+  private async ensureSingleOccurrences(): Promise<void> {
+    // Ensure a single occurrence exists for non-recurring tasks with a scheduled date.
+    const tasks = await this.all<any>(
+      `SELECT T.ID AS TASK_ID, DATE(COALESCE(T.DUE_AT, T.START_DATE)) AS S_DATE, T.START_TIME
+       FROM TASKS T
+       WHERE T.IS_RECURRING = 0 AND (T.STATUS IS NULL OR T.STATUS != 'archived')
+         AND DATE(COALESCE(T.DUE_AT, T.START_DATE)) IS NOT NULL`
+    );
+    const nowIso = this.nowIso();
+    for (const t of tasks) {
+      const rule = await this.get<any>('SELECT ID FROM RECURRENCE_RULES WHERE TASK_ID = ?', [t.TASK_ID]);
+      if (!rule) {
+        await this.run(
+          `INSERT INTO RECURRENCE_RULES (TASK_ID, FREQ, MONTHLY_DAY, COUNT, CREATED_AT, UPDATED_AT) VALUES (?, ?, ?, ?, ?, ?)`,
+          [t.TASK_ID, 'monthly', null, 1, nowIso, nowIso]
+        );
+      }
+      const scheduledDate = t.S_DATE as string;
+      const exists = await this.get<any>(
+        `SELECT ID FROM TASK_OCCURRENCES WHERE TASK_ID = ? AND SCHEDULED_DATE = ?`,
+        [t.TASK_ID, scheduledDate]
+      );
+      if (!exists) {
+        await this.run(
+          `INSERT INTO TASK_OCCURRENCES (TASK_ID, SCHEDULED_DATE, SCHEDULED_TIME, STATUS, CREATED_AT, UPDATED_AT)
+           VALUES (?, ?, ?, 'pending', ?, ?)`,
+          [t.TASK_ID, scheduledDate, t.START_TIME || null, nowIso, nowIso]
+        );
+      }
+    }
+  }
+
+  async listOccurrences(params: { from?: string; to?: string; query?: string; status?: string } = {}): Promise<any[]> {
+    // Ensure occurrences exist for both recurring and single tasks
+    await this.ensureSingleOccurrences();
+    await this.ensureRecurringMonthlyOccurrences(2);
+
+    const where: string[] = [];
+    const binds: any[] = [];
+    if (params.from) { where.push('O.SCHEDULED_DATE >= ?'); binds.push(params.from); }
+    if (params.to) { where.push('O.SCHEDULED_DATE <= ?'); binds.push(params.to); }
+    if (params.status) { where.push('O.STATUS = ?'); binds.push(params.status); }
+    if (params.query) { where.push('(T.TITLE LIKE ? OR T.DESCRIPTION LIKE ?)'); binds.push(`%${params.query}%`, `%${params.query}%`); }
+    const sql = `SELECT O.ID AS OCCURRENCE_ID, O.SCHEDULED_DATE, O.SCHEDULED_TIME, O.STATUS AS OCC_STATUS, O.COMPLETED_AT,
+                        T.ID AS TASK_ID, T.TITLE, T.DESCRIPTION, T.STATUS AS TASK_STATUS, T.PRIORITY,
+                        T.START_DATE, T.START_TIME, T.IS_RECURRING,
+                        R.FREQ, R.MONTHLY_DAY, R.COUNT
+                 FROM TASK_OCCURRENCES O
+                 JOIN TASKS T ON T.ID = O.TASK_ID
+                 LEFT JOIN RECURRENCE_RULES R ON R.TASK_ID = T.ID
+                 ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+                 ORDER BY O.SCHEDULED_DATE ASC, O.ID ASC`;
+    return this.all<any>(sql, binds);
+  }
+
+  async completeOccurrence(occurrenceId: number): Promise<void> {
+    const now = this.nowIso();
+    const occ = await this.get<any>(
+      `SELECT O.ID, O.TASK_ID, O.SCHEDULED_DATE, T.START_TIME, R.FREQ, R.MONTHLY_DAY
+       FROM TASK_OCCURRENCES O
+       JOIN TASKS T ON T.ID = O.TASK_ID
+       LEFT JOIN RECURRENCE_RULES R ON R.TASK_ID = T.ID
+       WHERE O.ID = ?`, [occurrenceId]
+    );
+    if (!occ) return;
+    await this.run(`UPDATE TASK_OCCURRENCES SET STATUS = 'done', COMPLETED_AT = ?, UPDATED_AT = ? WHERE ID = ?`, [now, now, occurrenceId]);
+    // Generate next monthly occurrence if needed
+    if (occ.FREQ === 'monthly' && occ.MONTHLY_DAY) {
+      const d = new Date(occ.SCHEDULED_DATE as string);
+      const nextMonth0 = (d.getMonth() + 1) % 12;
+      const nextYear = d.getFullYear() + (d.getMonth() === 11 ? 1 : 0);
+      const nextDate = this.clampMonthlyDate(nextYear, nextMonth0, Number(occ.MONTHLY_DAY));
+      const exists = await this.get<any>(`SELECT ID FROM TASK_OCCURRENCES WHERE TASK_ID = ? AND SCHEDULED_DATE = ?`, [occ.TASK_ID, nextDate]);
+      if (!exists) {
+        await this.run(
+          `INSERT INTO TASK_OCCURRENCES (TASK_ID, SCHEDULED_DATE, SCHEDULED_TIME, STATUS, CREATED_AT, UPDATED_AT)
+           VALUES (?, ?, ?, 'pending', ?, ?)`,
+          [occ.TASK_ID, nextDate, occ.START_TIME || null, now, now]
+        );
+      }
+    }
+  }
+
   private get<T>(sql: string, params: any[] = []): Promise<T | undefined> {
     return new Promise((resolve, reject) => {
       if (!this.db) return reject(new Error('Database not initialized'));
@@ -82,14 +212,21 @@ export class TaskDatabase {
     const binds: any[] = [];
     if (params.query) { where.push('(TITLE LIKE ? OR DESCRIPTION LIKE ?)'); binds.push(`%${params.query}%`, `%${params.query}%`); }
     if (params.status) { where.push('STATUS = ?'); binds.push(params.status); }
-    const sql = `SELECT ID, TITLE, DESCRIPTION, STATUS, PRIORITY, DUE_AT, START_DATE, START_TIME, IS_RECURRING, CREATED_AT, UPDATED_AT
-                 FROM TASKS ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
-                 ORDER BY COALESCE(UPDATED_AT, CREATED_AT) DESC, ID DESC`;
+    const sql = `SELECT T.ID, T.TITLE, T.DESCRIPTION, T.STATUS, T.PRIORITY, T.DUE_AT, T.START_DATE, T.START_TIME, T.IS_RECURRING,
+                        T.CREATED_AT, T.UPDATED_AT,
+                        R.FREQ, R.MONTHLY_DAY, R.COUNT
+                 FROM TASKS T
+                 LEFT JOIN RECURRENCE_RULES R ON R.TASK_ID = T.ID
+                 ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+                 ORDER BY COALESCE(T.UPDATED_AT, T.CREATED_AT) DESC, T.ID DESC`;
     return this.all<any>(sql, binds);
   }
 
   async getTask(id: number): Promise<any | undefined> {
-    const sql = 'SELECT * FROM TASKS WHERE ID = ?';
+    const sql = `SELECT T.*, R.FREQ, R.MONTHLY_DAY, R.COUNT
+                 FROM TASKS T
+                 LEFT JOIN RECURRENCE_RULES R ON R.TASK_ID = T.ID
+                 WHERE T.ID = ?`;
     return this.get<any>(sql, [id]);
   }
 
@@ -105,9 +242,48 @@ export class TaskDatabase {
       start_time: payload.startTime || null,
       is_recurring: payload.isRecurring ? 1 : 0
     };
+    // Default start_date/time if unspecified
+    if (!p.start_date) {
+      const d = new Date();
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, '0');
+      const da = String(d.getDate()).padStart(2, '0');
+      p.start_date = `${y}-${m}-${da}`;
+    }
+    if (!p.start_time) {
+      p.start_time = '00:00';
+    }
     const sql = `INSERT INTO TASKS (TITLE, DESCRIPTION, STATUS, PRIORITY, DUE_AT, START_DATE, START_TIME, IS_RECURRING, CREATED_AT, UPDATED_AT)
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
     const id = await this.run(sql, [p.title, p.description, p.status, p.priority, p.due_at, p.start_date, p.start_time, p.is_recurring, now, now]);
+    // Insert recurrence rule: for recurring, from payload; for single, COUNT=1
+    const rec = payload.recurrence;
+    if (p.is_recurring && rec && rec.freq === 'monthly' && rec.monthlyDay && rec.monthlyDay >= 1 && rec.monthlyDay <= 31) {
+      const rsql = `INSERT INTO RECURRENCE_RULES (TASK_ID, FREQ, MONTHLY_DAY, COUNT, CREATED_AT, UPDATED_AT)
+                    VALUES (?, ?, ?, ?, ?, ?)`;
+      const count = Math.max(0, Number((rec as any).count || 0) || 0); // 0=無限
+      await this.run(rsql, [id, 'monthly', rec.monthlyDay, count, now, now]);
+    } else {
+      // Non-recurring: create a rule row with COUNT=1
+      const rsql = `INSERT INTO RECURRENCE_RULES (TASK_ID, FREQ, MONTHLY_DAY, COUNT, CREATED_AT, UPDATED_AT)
+                    VALUES (?, ?, ?, ?, ?, ?)`;
+      await this.run(rsql, [id, 'monthly', null, 1, now, now]);
+    }
+
+    // For single tasks, ensure one occurrence exists immediately
+    if (!p.is_recurring) {
+      const scheduledDate = p.due_at ? (p.due_at.split('T')[0]) : p.start_date;
+      if (scheduledDate) {
+        const exists = await this.get<any>('SELECT ID FROM TASK_OCCURRENCES WHERE TASK_ID = ? AND SCHEDULED_DATE = ?', [id, scheduledDate]);
+        if (!exists) {
+          await this.run(
+            `INSERT INTO TASK_OCCURRENCES (TASK_ID, SCHEDULED_DATE, SCHEDULED_TIME, STATUS, CREATED_AT, UPDATED_AT)
+             VALUES (?, ?, ?, 'pending', ?, ?)`,
+            [id, scheduledDate, p.start_time || null, now, now]
+          );
+        }
+      }
+    }
     return id;
   }
 
@@ -125,6 +301,42 @@ export class TaskDatabase {
       is_recurring: payload.isRecurring ? 1 : 0
     };
     await this.run(sql, [p.title, p.description, p.status, p.priority, p.due_at, p.start_date, p.start_time, p.is_recurring, now, id]);
+    // Upsert/delete recurrence rule based on payload
+    const rec = payload.recurrence;
+    if (p.is_recurring && rec && rec.freq === 'monthly' && rec.monthlyDay && rec.monthlyDay >= 1 && rec.monthlyDay <= 31) {
+      // Check if rule exists
+      const existing = await this.get<any>('SELECT ID FROM RECURRENCE_RULES WHERE TASK_ID = ?', [id]);
+      const count = Math.max(0, Number((rec as any).count || 0) || 0);
+      if (existing && existing.ID) {
+        await this.run('UPDATE RECURRENCE_RULES SET FREQ = ?, MONTHLY_DAY = ?, COUNT = ?, UPDATED_AT = ? WHERE TASK_ID = ?',
+          ['monthly', rec.monthlyDay, count, now, id]);
+      } else {
+        await this.run('INSERT INTO RECURRENCE_RULES (TASK_ID, FREQ, MONTHLY_DAY, COUNT, CREATED_AT, UPDATED_AT) VALUES (?, ?, ?, ?, ?, ?)',
+          [id, 'monthly', rec.monthlyDay, count, now, now]);
+      }
+    } else {
+      // Non-recurring: ensure rule with COUNT=1 exists
+      const existing = await this.get<any>('SELECT ID FROM RECURRENCE_RULES WHERE TASK_ID = ?', [id]);
+      if (existing && existing.ID) {
+        await this.run('UPDATE RECURRENCE_RULES SET FREQ = ?, MONTHLY_DAY = ?, COUNT = ?, UPDATED_AT = ? WHERE TASK_ID = ?',
+          ['monthly', null, 1, now, id]);
+      } else {
+        await this.run('INSERT INTO RECURRENCE_RULES (TASK_ID, FREQ, MONTHLY_DAY, COUNT, CREATED_AT, UPDATED_AT) VALUES (?, ?, ?, ?, ?, ?)',
+          [id, 'monthly', null, 1, now, now]);
+      }
+      // Ensure single occurrence exists
+      const scheduledDate = p.due_at ? (p.due_at.split('T')[0]) : p.start_date;
+      if (scheduledDate) {
+        const exists = await this.get<any>('SELECT ID FROM TASK_OCCURRENCES WHERE TASK_ID = ? AND SCHEDULED_DATE = ?', [id, scheduledDate]);
+        if (!exists) {
+          await this.run(
+            `INSERT INTO TASK_OCCURRENCES (TASK_ID, SCHEDULED_DATE, SCHEDULED_TIME, STATUS, CREATED_AT, UPDATED_AT)
+             VALUES (?, ?, ?, 'pending', ?, ?)`,
+            [id, scheduledDate, p.start_time || null, now, now]
+          );
+        }
+      }
+    }
   }
 
   async deleteTask(id: number): Promise<void> {

--- a/task-editor.html
+++ b/task-editor.html
@@ -60,11 +60,12 @@
           <div class="row"><label for="isRecurring">繰り返し</label><select id="isRecurring"><option value="0">オフ</option><option value="1">オン</option></select></div>
           <div class="row"><label for="startDate">開始日</label><input id="startDate" type="date" /></div>
           <div class="row"><label for="startTime">開始時刻</label><input id="startTime" type="time" /></div>
-          <div class="small">繰り返しルールの詳細（第N曜日など）は後続で追加予定です。</div>
+          <div class="row"><label for="monthlyDay">毎月の開始日</label><input id="monthlyDay" type="number" min="1" max="31" placeholder="1..31" /></div>
+          <div class="row"><label for="recurrenceCount">繰り返し回数</label><input id="recurrenceCount" type="number" min="0" placeholder="0=無限, 1.." /></div>
+          <div class="small">「繰り返し=オン」で「毎月の開始日」を指定すると、毎月その日に開始するタスクとして保存します（第N曜日などは後続で追加予定）。</div>
         </form>
       </section>
     </main>
-    <script src="js/taskEditor.js"></script>
+    <script type="module" src="js/taskEditor.js"></script>
   </body>
   </html>
-

--- a/task-view.html
+++ b/task-view.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' file: data:;" />
+    <title>タスク表示 - NyanTaskNotes</title>
+    <style>
+      body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+      header { display: flex; align-items: center; justify-content: space-between; padding: 10px 16px; border-bottom: 1px solid #ddd; }
+      main { padding: 12px 16px; }
+      #toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+      #search { padding: 8px; min-width: 240px; }
+      #statusFilter, #refreshBtn { padding: 8px; }
+      #taskList { display: grid; gap: 8px; }
+      .task { border: 1px solid #eee; border-radius: 6px; padding: 10px 12px; display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; }
+      .title { font-weight: 600; }
+      .meta { color: #666; font-size: 12px; margin-top: 4px; }
+      .actions { display: flex; gap: 6px; align-items: center; }
+      button { padding: 6px 10px; }
+      .done { background: #f4fff4; border-color: #cfe9cf; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>タスク表示</div>
+      <div class="actions">
+        <button id="refreshBtn">再読み込み</button>
+      </div>
+    </header>
+    <main>
+      <div id="toolbar">
+        <input id="search" type="text" placeholder="検索 (タイトル/説明)" />
+        <select id="statusFilter">
+          <option value="">すべて</option>
+          <option value="pending">pending</option>
+          <option value="done">done</option>
+        </select>
+      </div>
+      <div id="taskList"></div>
+    </main>
+    <script type="module" src="js/taskViewer.js"></script>
+  </body>
+  </html>


### PR DESCRIPTION
…(COUNT=1)を作成し、表示は TASK_OCCURRENCES 経由に統一（UNION 廃止）\n- タスク表示前に ensureSingleOccurrences を実行して単発タスクのオカレンスを生成\n- 編集画面に「繰り返し回数」を追加し COUNT を保存（0=無限、繰り返しオフは1固定）\n- DB I/O: listOccurrences/listTasks/getTask で R.COUNT を返すように変更\n- INTERVAL 関連の参照/保存を削除（未使用のため）\n- 開始日のデフォルトを本日、開始時刻のデフォルトを 00:00 に設定\n\n注意: 既存の単発タスクは表示時に不足するルール行/オカレンスを自動補完します。