### PR TITLE
feat: 指定日数ごとの繰り返し（発生基準/完了基準）を追加

### DIFF
--- a/src/renderer/taskViewer.ts
+++ b/src/renderer/taskViewer.ts
@@ -26,6 +26,22 @@ function formatDateInput(dateStr?: string | null): string {
   return `${y}-${m}-${da}`;
 }
 
+function formatDateWithWeekday(dateStr?: string | null): string {
+  const base = formatDateInput(dateStr);
+  if (!base) return '';
+  // Compute weekday using local date to avoid TZ issues
+  let d: Date;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(base)) {
+    const [yy, mm, dd] = base.split('-').map(Number);
+    d = new Date(yy, mm - 1, dd);
+  } else {
+    d = new Date(base);
+  }
+  const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
+  const w = weekdays[d.getDay()];
+  return `${base} (${w})`;
+}
+
 function ymd(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, '0');
@@ -154,7 +170,7 @@ async function loadTasks(): Promise<void> {
       left.appendChild(titleRow);
       const metaRow = document.createElement('div');
       metaRow.className = 'meta';
-      metaRow.textContent = `予定日: ${formatDateInput(o.SCHEDULED_DATE)} ・ タスク: ${o.TASK_ID} ・ 状態: ${o.OCC_STATUS}`;
+      metaRow.textContent = `予定日: ${formatDateWithWeekday(o.SCHEDULED_DATE)} ・ タスク: ${o.TASK_ID} ・ 状態: ${o.OCC_STATUS}`;
       left.appendChild(metaRow);
       const actions = document.createElement('div');
       actions.className = 'actions';

--- a/task-editor.html
+++ b/task-editor.html
@@ -61,12 +61,15 @@
             <select id="isRecurring">
               <option value="once">１回のみ</option>
               <option value="daily">毎日</option>
+              <option value="everyNScheduled">指定日数ごと（前回発生した日付から）</option>
+              <option value="everyNCompleted">指定日数ごと（前回完了した日付から）</option>
               <option value="monthly">毎月（日付）</option>
               <option value="monthlyNth">第n週m曜日</option>
             </select>
           </div>
           <div class="row"><label for="startDate">開始日</label><input id="startDate" type="date" /></div>
           <div class="row"><label for="startTime">開始時刻</label><input id="startTime" type="time" /></div>
+          <div class="row"><label for="intervalDays">間隔（日）</label><input id="intervalDays" type="number" min="1" max="365" placeholder="例: 2" /></div>
           <div class="row"><label for="monthlyDay">毎月の開始日</label><input id="monthlyDay" type="number" min="1" max="31" placeholder="1..31" /></div>
           <div class="row"><label for="monthlyNth">第n週</label>
             <select id="monthlyNth">
@@ -88,8 +91,8 @@
             </select>
           </div>
           <div class="row"><label for="recurrenceCount">繰り返し回数</label><input id="recurrenceCount" type="number" min="0" placeholder="0=無限, 1.." /></div>
-          <div class="row"><label for="dailyHorizonDays">生成日数（毎日）</label><input id="dailyHorizonDays" type="number" min="1" max="365" placeholder="例: 14" /></div>
-          <div class="small">「繰り返し」で「毎月（日付）」は毎月の同じ日付。「第n週m曜日」は毎月の特定の週と曜日（例: 第2週火曜/最終週金曜）。「毎日」は開始日から毎日生成します。なお「毎日」を選択すると、既定で「生成日数（毎日）」は2日に設定されます（必要に応じて変更可）。</div>
+          <div class="row"><label for="dailyHorizonDays">生成日数（毎日/指定日数・発生基準）</label><input id="dailyHorizonDays" type="number" min="1" max="365" placeholder="例: 14" /></div>
+          <div class="small">「毎日」は開始日から毎日生成します。「指定日数ごと（前回発生した日付から）」は予定日を基準に n 日間隔で生成し、先出し生成します。「指定日数ごと（前回完了した日付から）」は完了日を基準に n 日後を1件だけ生成します。なお「毎日」を選択すると、既定で「生成日数」は2日に設定されます（必要に応じて変更可）。</div>
         </form>
       </section>
     </main>


### PR DESCRIPTION
- 概要
      - 指定日数ごとの繰り返しを2種追加
          - 指定日数ごと（前回発生した日付から）: anchor=scheduled
          - 指定日数ごと（前回完了した日付から）: anchor=completed
      - INTERVAL/INTERVAL_ANCHOR を導入（'scheduled' | 'completed'）
      - 軽量マイグレーションで INTERVAL_ANCHOR 列を追加（既存は 'scheduled' として互換）
  - 仕様
      - 発生基準（scheduled）
          - START_DATE を基準に INTERVAL 日ごとに先出し生成（HORIZON_DAYS 範囲）
          - COUNT が有限の場合は START_DATE + k*INTERVAL に正規化
      - 完了基準（completed）
          - 常に pending は最大1件のみ（COUNT が有限でも同様）
          - 初回生成: START_DATE で1件のみ（INTERVAL を加算しない）
          - 完了時: 完了日（ローカル日）+ INTERVAL に1件のみ生成
  - UI
      - 「繰り返し」に2項目を追加
          - 指定日数ごと（前回発生した日付から）
          - 指定日数ごと（前回完了した日付から）
      - 「間隔（日）」入力を追加（1..365）
      - 「生成日数」は「毎日」「指定日数・発生基準」で表示
  - 実装ポイント
      - RECURRENCE_RULES: INTERVAL_ANCHOR を追加（自動マイグレーション）
      - 生成: daily/scheduled は INTERVAL を考慮して先出し、daily/completed は pending=1件維持（初回は START_DATE、その後は完了日基準）
      - 完了処理: anchor に応じて次回日付の起点を分岐（scheduled=予定日、completed=完了日）
      - 取得/保存: interval, anchor を read/write
  - 確認手順
      - 指定日数（発生基準）で interval=2 を指定し、先出し生成が 2 日おきで並ぶこと
      - 指定日数（完了基準）で新規作成直後は START_DATE に1件のみ pending であること
      - 完了後、完了日+interval の1件のみが生成され、pending が常に1件であること（COUNT 有限でも同様）
      - 既存 DB で起動してもエラーなく動作すること（INTERVAL_ANCHOR の自動追加）