### PR TITLE
feat: 新タスク編集画面の追加＋週次/年次繰り返し・ユーティリティ分離

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,8 @@ function createMenu(): void {
       submenu: [
         { label: 'Top', click: () => mainWindow?.loadFile('index.html') },
         { label: 'タスク表示', click: () => mainWindow?.loadFile('task-view.html') },
-        { label: 'タスク編集', click: () => mainWindow?.loadFile('task-editor.html') }
+        { label: 'タスク編集', click: () => mainWindow?.loadFile('task-editor.html') },
+        { label: 'タスク編集（新規/新画面）', click: () => mainWindow?.loadFile('task-editor2.html', { query: { new: '1' } }) }
       ]
     }
   ];

--- a/src/renderer/sharedTaskEditor.ts
+++ b/src/renderer/sharedTaskEditor.ts
@@ -1,0 +1,80 @@
+// 共通ユーティリティ（タスク編集画面向け）
+
+export type TaskRow = {
+  ID?: number;
+  TITLE: string;
+  DESCRIPTION?: string | null;
+  TAGS?: string[];
+  DUE_AT?: string | null;
+  START_DATE?: string | null;
+  START_TIME?: string | null;
+  IS_RECURRING?: number;
+  // Recurrence rule (joined columns)
+  FREQ?: string | null;
+  INTERVAL?: number | null;
+  INTERVAL_ANCHOR?: string | null;
+  MONTHLY_DAY?: number | null;
+  MONTHLY_NTH?: number | null;
+  MONTHLY_NTH_DOW?: number | null;
+  YEARLY_MONTH?: number | null;
+  COUNT?: number | null;
+  HORIZON_DAYS?: number | null;
+  WEEKLY_DOWS?: number | null;
+};
+
+export type RecurrenceUIMode =
+  | 'once'
+  | 'daily'
+  | 'everyNScheduled'
+  | 'everyNCompleted'
+  | 'weekly'
+  | 'monthly'
+  | 'monthlyNth'
+  | 'yearly';
+
+export function formatDateInput(dateStr?: string | null): string {
+  if (!dateStr) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return '';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const da = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${da}`;
+}
+
+// DBの行からUIモードを推定
+export function inferRecurrenceModeFromDb(t: TaskRow): RecurrenceUIMode {
+  if (!t.IS_RECURRING) return 'once';
+  if (t.FREQ === 'monthly') {
+    if ((t as any).MONTHLY_NTH !== null && typeof (t as any).MONTHLY_NTH !== 'undefined') return 'monthlyNth';
+    return 'monthly';
+  }
+  if (t.FREQ === 'yearly') return 'yearly';
+  if (t.FREQ === 'weekly') return 'weekly';
+  if (t.FREQ === 'daily') {
+    const interval = Number((t as any).INTERVAL || 1);
+    const anchor = (t as any).INTERVAL_ANCHOR || 'scheduled';
+    if (anchor === 'completed') return 'everyNCompleted';
+    if (interval > 1) return 'everyNScheduled';
+    return 'daily';
+  }
+  return 'daily';
+}
+
+// 週次: 配列<0..6> からビットマスクへ
+export function weeklyMaskFromArray(dows: number[]): number {
+  let mask = 0;
+  for (const v of dows) {
+    if (Number.isInteger(v) && v >= 0 && v <= 6) mask |= (1 << v);
+  }
+  return mask >>> 0;
+}
+
+// 週次: ビットマスクから配列<0..6> へ
+export function weeklyArrayFromMask(mask: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i <= 6; i++) if (mask & (1 << i)) out.push(i);
+  return out;
+}
+

--- a/src/renderer/taskViewer.ts
+++ b/src/renderer/taskViewer.ts
@@ -164,7 +164,7 @@ async function loadTasks(): Promise<void> {
       editBtn.style.cursor = 'pointer';
       editBtn.style.marginLeft = '8px';
       editBtn.style.fontSize = '12px';
-      editBtn.onclick = () => { window.location.href = `task-editor.html?id=${o.TASK_ID}`; };
+      editBtn.onclick = () => { window.location.href = `task-editor2.html?id=${o.TASK_ID}`; };
       titleRow.appendChild(titleSpan);
       titleRow.appendChild(editBtn);
       left.appendChild(titleRow);

--- a/task-editor.html
+++ b/task-editor.html
@@ -66,6 +66,7 @@
               <option value="everyNCompleted">指定日数ごと（前回完了した日付から）</option>
               <option value="monthly">毎月（日付）</option>
               <option value="monthlyNth">第n週m曜日</option>
+              <option value="yearly">毎年（月日）</option>
             </select>
           </div>
           <div class="row"><label>曜日</label>
@@ -83,6 +84,23 @@
           <div class="row"><label for="startTime">開始時刻</label><input id="startTime" type="time" /></div>
           <div class="row"><label for="intervalDays">間隔（日）</label><input id="intervalDays" type="number" min="1" max="365" placeholder="例: 2" /></div>
           <div class="row"><label for="monthlyDay">毎月の開始日</label><input id="monthlyDay" type="number" min="1" max="31" placeholder="1..31" /></div>
+          <div class="row"><label for="yearlyMonth">毎年の月</label>
+            <select id="yearlyMonth">
+              <option value="1">1月</option>
+              <option value="2">2月</option>
+              <option value="3">3月</option>
+              <option value="4">4月</option>
+              <option value="5">5月</option>
+              <option value="6">6月</option>
+              <option value="7">7月</option>
+              <option value="8">8月</option>
+              <option value="9">9月</option>
+              <option value="10">10月</option>
+              <option value="11">11月</option>
+              <option value="12">12月</option>
+            </select>
+          </div>
+          <div class="row"><label for="yearlyDay">毎年の日</label><input id="yearlyDay" type="number" min="1" max="31" placeholder="1..31" /></div>
           <div class="row"><label for="monthlyNth">第n週</label>
             <select id="monthlyNth">
               <option value="1">第1</option>

--- a/task-editor.html
+++ b/task-editor.html
@@ -61,10 +61,22 @@
             <select id="isRecurring">
               <option value="once">１回のみ</option>
               <option value="daily">毎日</option>
+              <option value="weekly">毎週（曜日）</option>
               <option value="everyNScheduled">指定日数ごと（前回発生した日付から）</option>
               <option value="everyNCompleted">指定日数ごと（前回完了した日付から）</option>
               <option value="monthly">毎月（日付）</option>
               <option value="monthlyNth">第n週m曜日</option>
+            </select>
+          </div>
+          <div class="row"><label for="weeklyDow">曜日</label>
+            <select id="weeklyDow">
+              <option value="0">日曜日</option>
+              <option value="1">月曜日</option>
+              <option value="2">火曜日</option>
+              <option value="3">水曜日</option>
+              <option value="4">木曜日</option>
+              <option value="5">金曜日</option>
+              <option value="6">土曜日</option>
             </select>
           </div>
           <div class="row"><label for="startDate">開始日</label><input id="startDate" type="date" /></div>

--- a/task-editor.html
+++ b/task-editor.html
@@ -68,16 +68,16 @@
               <option value="monthlyNth">第n週m曜日</option>
             </select>
           </div>
-          <div class="row"><label for="weeklyDow">曜日</label>
-            <select id="weeklyDow">
-              <option value="0">日曜日</option>
-              <option value="1">月曜日</option>
-              <option value="2">火曜日</option>
-              <option value="3">水曜日</option>
-              <option value="4">木曜日</option>
-              <option value="5">金曜日</option>
-              <option value="6">土曜日</option>
-            </select>
+          <div class="row"><label>曜日</label>
+            <div id="weeklyDows" style="display:flex; gap:8px; flex-wrap: wrap;">
+              <label><input type="checkbox" value="0"> 日</label>
+              <label><input type="checkbox" value="1"> 月</label>
+              <label><input type="checkbox" value="2"> 火</label>
+              <label><input type="checkbox" value="3"> 水</label>
+              <label><input type="checkbox" value="4"> 木</label>
+              <label><input type="checkbox" value="5"> 金</label>
+              <label><input type="checkbox" value="6"> 土</label>
+            </div>
           </div>
           <div class="row"><label for="startDate">開始日</label><input id="startDate" type="date" /></div>
           <div class="row"><label for="startTime">開始時刻</label><input id="startTime" type="time" /></div>

--- a/task-editor2.html
+++ b/task-editor2.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' file: data:;" />
+    <title>タスク編集（新） - NyanTaskNotes</title>
+    <style>
+      body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+      header { display: flex; align-items: center; justify-content: space-between; padding: 10px 16px; border-bottom: 1px solid #ddd; }
+      main { display: grid; grid-template-columns: 420px 1fr; height: calc(100vh - 52px); }
+      #left { border-right: 1px solid #eee; padding: 16px; overflow: auto; }
+      #right { padding: 16px; overflow: auto; }
+      .row { display: flex; gap: 8px; align-items: center; margin: 8px 0; }
+      label { width: 120px; color: #333; }
+      input[type=text], input[type=date], input[type=time], input[type=number], select, textarea { flex: 1; padding: 6px 8px; }
+      textarea { min-height: 80px; }
+      .actions { display: flex; gap: 8px; }
+      h3 { margin-top: 20px; }
+      .pill { display:inline-block; padding:2px 8px; border-radius:12px; font-size:12px; }
+      .add { background:#e8f7ea; color:#0a7a1b; }
+      .del { background:#fde8e8; color:#b41111; }
+      .same { background:#f1f1f1; color:#555; }
+      .list { display:flex; flex-direction:column; gap:6px; }
+      .occ { display:flex; gap:8px; align-items:center; border-bottom:1px solid #f3f3f3; padding:6px 0; }
+      .meta { color:#666; font-size:12px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>タスク編集（新）</div>
+      <div class="actions">
+        <select id="previewRange">
+          <option value="8w">8週間</option>
+          <option value="6m">6ヶ月</option>
+          <option value="12m">12ヶ月</option>
+          <option value="2y">2年</option>
+        </select>
+        <button id="saveBtn">保存</button>
+        <button id="deleteBtn">削除</button>
+      </div>
+    </header>
+    <main>
+      <section id="left">
+        <form id="taskForm" onsubmit="return false;">
+          <input type="hidden" id="taskId" />
+          <div class="row"><label for="title">タイトル</label><input id="title" type="text" required /></div>
+          <div class="row"><label for="description">説明</label><textarea id="description"></textarea></div>
+          <div class="row"><label for="tags">タグ</label><input id="tags" type="text" placeholder="カンマ区切り" /></div>
+          <div class="row"><label for="dueAt">期日（単発）</label><input id="dueAt" type="date" /></div>
+          <h3>繰り返し</h3>
+          <div class="row"><label for="isRecurring">繰り返し</label>
+            <select id="isRecurring">
+              <option value="once">１回のみ</option>
+              <option value="daily">毎日</option>
+              <option value="everyNScheduled">指定日数ごと（前回発生した日付から）</option>
+              <option value="everyNCompleted">指定日数ごと（前回完了した日付から）</option>
+              <option value="weekly">毎週（曜日）</option>
+              <option value="monthly">毎月（日付）</option>
+              <option value="monthlyNth">第n週m曜日</option>
+              <option value="yearly">毎年（月日）</option>
+            </select>
+          </div>
+          <div class="row"><label for="startDate">開始日</label><input id="startDate" type="date" /></div>
+          <div class="row"><label for="startTime">開始時刻</label><input id="startTime" type="time" /></div>
+          <div class="row" id="rowInterval"><label for="intervalDays">間隔（日）</label><input id="intervalDays" type="number" min="1" max="365" placeholder="例: 2" /></div>
+          <div class="row" id="rowHorizon"><label for="dailyHorizonDays">生成日数（日次・発生基準）</label><input id="dailyHorizonDays" type="number" min="1" max="365" placeholder="例: 14" /></div>
+          <div class="row" id="rowMonthlyDay"><label for="monthlyDay">毎月の日</label><input id="monthlyDay" type="number" min="1" max="31" placeholder="1..31" /></div>
+          <div class="row" id="rowMonthlyNth"><label for="monthlyNth">第n週</label>
+            <select id="monthlyNth">
+              <option value="1">第1</option>
+              <option value="2">第2</option>
+              <option value="3">第3</option>
+              <option value="4">第4</option>
+              <option value="5">第5</option>
+              <option value="-1">最終</option>
+            </select>
+            <select id="monthlyNthDow" style="flex:1;">
+              <option value="0">日曜日</option>
+              <option value="1">月曜日</option>
+              <option value="2">火曜日</option>
+              <option value="3">水曜日</option>
+              <option value="4">木曜日</option>
+              <option value="5">金曜日</option>
+              <option value="6">土曜日</option>
+            </select>
+          </div>
+          <div class="row" id="rowWeekly"><label>曜日</label>
+            <div id="weeklyDows" style="display:flex; gap:8px; flex-wrap: wrap;">
+              <label><input type="checkbox" value="0"> 日</label>
+              <label><input type="checkbox" value="1"> 月</label>
+              <label><input type="checkbox" value="2"> 火</label>
+              <label><input type="checkbox" value="3"> 水</label>
+              <label><input type="checkbox" value="4"> 木</label>
+              <label><input type="checkbox" value="5"> 金</label>
+              <label><input type="checkbox" value="6"> 土</label>
+            </div>
+          </div>
+          <div class="row" id="rowYearlyMonth"><label for="yearlyMonth">毎年の月</label>
+            <select id="yearlyMonth">
+              <option value="1">1月</option>
+              <option value="2">2月</option>
+              <option value="3">3月</option>
+              <option value="4">4月</option>
+              <option value="5">5月</option>
+              <option value="6">6月</option>
+              <option value="7">7月</option>
+              <option value="8">8月</option>
+              <option value="9">9月</option>
+              <option value="10">10月</option>
+              <option value="11">11月</option>
+              <option value="12">12月</option>
+            </select>
+          </div>
+          <div class="row" id="rowYearlyDay"><label for="yearlyDay">毎年の日</label><input id="yearlyDay" type="number" min="1" max="31" placeholder="1..31" /></div>
+          <div class="row"><label for="recurrenceCount">繰り返し回数</label><input id="recurrenceCount" type="number" min="0" placeholder="0=無限, 1.." /></div>
+        </form>
+      </section>
+      <section id="right">
+        <div class="row" style="justify-content: space-between;">
+          <div class="meta">プレビュー（保存時の差分を表示）</div>
+          <label class="meta"><input type="checkbox" id="excludeDoneDeletes" /> 完了済みは削除しない</label>
+        </div>
+        <div id="preview">
+          <h3><span class="pill add">追加予定</span></h3>
+          <div id="listAdd" class="list"></div>
+          <h3><span class="pill del">削除予定</span></h3>
+          <div id="listDel" class="list"></div>
+          <h3><span class="pill same">変更なし</span></h3>
+          <div id="listSame" class="list"></div>
+        </div>
+      </section>
+    </main>
+    <script type="module" src="js/taskEditor2.js"></script>
+  </body>
+  </html>
+


### PR DESCRIPTION
feat: 新タスク編集画面の追加＋週次/年次繰り返し・ユーティリティ分離

            概要
              - 単一タスク編集の新画面を追加（task-editor2.html）。右ペインで保存時の差分（追加/削除/変更なし）をプレビュー
              - 週次の複数曜日、年次（毎年N月M日）をサポート
              - 共有ユーティリティ（型/日付整形/モード推定/週次ビット変換）を分離
              - メニューから新規で新画面を開けるようにし、タスク表示の編集遷移も新画面へ変更

            変更点
              - UI: task-editor2.html（既存項目に準拠しつつプレビュー機能を追加）
              - Renderer: taskEditor2.ts（プレビュー差分算出/保存時警告）、sharedTaskEditor.ts（共通化）
              - DB: WEEKLY_DOWS / YEARLY_MONTH の軽量マイグレーション、週次/年次の生成・正規化・完了時次回生成
              - メニュー: 新画面の新規起動、表示画面の編集遷移先を新画面へ変更

            スキーマ/マイグレーション
              - RECURRENCE_RULES: WEEKLY_DOWS, YEARLY_MONTH を不足時のみ追加

            動作確認
              - メニューから「タスク編集（新規/新画面）」起動 → 新規作成・プレビュー表示
              - タスク表示→編集アイコン→新画面で該当ID表示
              - 週次（複数曜日）/年次のプレビュー生成、COUNT>=1 正規化
              - 日次（完了基準）は1件プレビュー、保存時に削除候補に完了済みが含まれる場合は警告表示

            注意
              - プレビューはフロント側のシミュレータで算出（将来はIPCドライランAPIで厳密一致に）
