### PR TITLE
feat: タグ名編集画面を追加

### DIFF
--- a/src/ipc/taskHandlers.ts
+++ b/src/ipc/taskHandlers.ts
@@ -139,6 +139,29 @@ export function registerTaskIpcHandlers(opts: {
     }
   });
 
+  ipcMain.handle('task-tags:list-infos', async () => {
+    const db = getTaskDb();
+    if (!db) return [];
+    try {
+      return await (db as any).listTagInfos();
+    } catch (e) {
+      log.error('task-tags:list-infos error', e);
+      throw e;
+    }
+  });
+
+  ipcMain.handle('task-tags:rename', async (_event, id: number, name: string) => {
+    const db = getTaskDb();
+    if (!db) return { success: false, message: 'タスクDBが初期化されていません' };
+    try {
+      await (db as any).renameTag(id, name);
+      return { success: true };
+    } catch (e: any) {
+      log.error('task-tags:rename error', e);
+      return { success: false, message: e?.message || 'タグ名の更新に失敗しました' };
+    }
+  });
+
   // Task events (logs)
   ipcMain.handle('events:list', async (_event, params: { taskId: number; limit?: number } ) => {
     const db = getTaskDb();

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,7 @@ function createMenu(): void {
       submenu: [
         { label: 'Top', click: () => mainWindow?.loadFile('index.html') },
         { label: '設定', click: () => mainWindow?.loadFile('settings.html') },
+        { label: 'タグ編集', click: () => mainWindow?.loadFile('tag-manager.html') },
         { label: 'タスク設定一覧', click: () => mainWindow?.loadFile('task-settings.html') },
         { label: 'タスク表示', click: () => mainWindow?.loadFile('task-view.html') },
         { label: 'タスク編集', click: () => mainWindow?.loadFile('task-editor.html') },

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -29,7 +29,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   deferOccurrence: (id: number, newDate?: string | null) => ipcRenderer.invoke('occ:defer', id, newDate ?? null)
   ,
   // Task tags
-  listTaskTags: () => ipcRenderer.invoke('task-tags:list')
+  listTaskTags: () => ipcRenderer.invoke('task-tags:list'),
+  listTaskTagInfos: () => ipcRenderer.invoke('task-tags:list-infos'),
+  renameTaskTag: (id: number, name: string) => ipcRenderer.invoke('task-tags:rename', id, name)
   ,
   // Events (logs)
   listEvents: (params: { taskId: number; limit?: number }) => ipcRenderer.invoke('events:list', params)
@@ -59,6 +61,8 @@ declare global {
       completeOccurrence: (id: number, options?: { comment?: string }) => Promise<{ success: boolean }>;
       deferOccurrence: (id: number, newDate?: string | null) => Promise<{ success: boolean }>;
       listTaskTags: () => Promise<string[]>;
+      listTaskTagInfos: () => Promise<Array<{ id: number; name: string; createdAt: string | null; updatedAt: string | null }>>;
+      renameTaskTag: (id: number, name: string) => Promise<{ success: boolean; message?: string }>;
       listEvents: (params: { taskId: number; limit?: number }) => Promise<any[]>;
       promptText: (options: { title?: string; label?: string; placeholder?: string; ok?: string; cancel?: string }) => Promise<string | null>;
     };

--- a/src/renderer/tagManager.ts
+++ b/src/renderer/tagManager.ts
@@ -1,0 +1,138 @@
+(() => {
+  type TagInfo = { id: number; name: string; createdAt: string | null; updatedAt: string | null };
+  type StatusKind = 'info' | 'error' | 'success';
+
+  const state: { tags: TagInfo[]; filter: string; loading: boolean } = {
+    tags: [],
+    filter: '',
+    loading: false
+  };
+
+  const elements = {
+    tbody: document.getElementById('tagTableBody') as HTMLTableSectionElement,
+    empty: document.getElementById('emptyState') as HTMLDivElement,
+    status: document.getElementById('statusMessage') as HTMLSpanElement,
+    searchInput: document.getElementById('searchInput') as HTMLInputElement,
+    reloadButton: document.getElementById('reloadButton') as HTMLButtonElement
+  };
+
+  if (!elements.tbody || !elements.empty || !elements.status || !elements.searchInput || !elements.reloadButton) {
+    throw new Error('タグ編集画面の初期化に失敗しました');
+  }
+
+  function formatIso(iso: string | null): string {
+    if (!iso) return '-';
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return iso;
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+  }
+
+  function setStatus(message: string, kind: StatusKind = 'info'): void {
+    if (!elements.status) return;
+    elements.status.textContent = message;
+    elements.status.dataset.kind = kind;
+  }
+
+  function render(): void {
+    const keyword = state.filter.trim().toLowerCase();
+    const filtered = keyword
+      ? state.tags.filter(tag => tag.name.toLowerCase().includes(keyword))
+      : state.tags;
+    elements.tbody.innerHTML = '';
+    if (!filtered.length) {
+      elements.empty.hidden = false;
+      return;
+    }
+    elements.empty.hidden = true;
+    filtered.forEach(tag => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="col-id">${tag.id}</td>
+        <td class="col-name"><span>${tag.name}</span></td>
+        <td class="col-updated">${formatIso(tag.updatedAt)}</td>
+        <td class="col-actions"><button type="button" data-id="${tag.id}">名前を変更</button></td>
+      `;
+      const button = tr.querySelector('button');
+      if (button) {
+        button.addEventListener('click', () => renameTag(tag));
+      }
+      elements.tbody.appendChild(tr);
+    });
+  }
+
+  async function renameTag(tag: TagInfo): Promise<void> {
+    const input = await window.electronAPI.promptText({
+      title: 'タグ名を変更',
+      label: `新しいタグ名 (${tag.name})`,
+      placeholder: tag.name,
+      ok: '更新',
+      cancel: 'キャンセル'
+    });
+    if (input == null) {
+      setStatus('変更をキャンセルしました', 'info');
+      return;
+    }
+    const nextName = input.trim();
+    if (!nextName) {
+      setStatus('タグ名が空です', 'error');
+      return;
+    }
+    if (nextName === tag.name) {
+      setStatus('名前に変更はありません', 'info');
+      return;
+    }
+    try {
+      setStatus('更新中...', 'info');
+      const result = await window.electronAPI.renameTaskTag(tag.id, nextName);
+      if (!result?.success) {
+        setStatus(result?.message || 'タグ名の更新に失敗しました', 'error');
+        return;
+      }
+      setStatus('タグ名を更新しました', 'success');
+      await loadTags();
+    } catch (error) {
+      console.error(error);
+      setStatus(error instanceof Error ? error.message : '予期しないエラーが発生しました', 'error');
+    }
+  }
+
+  async function loadTags(): Promise<void> {
+    if (state.loading) return;
+    state.loading = true;
+    elements.reloadButton.disabled = true;
+    setStatus('読み込み中...', 'info');
+    try {
+      const tags = await window.electronAPI.listTaskTagInfos();
+      state.tags = tags;
+      render();
+      setStatus(`${tags.length}件のタグ`, 'info');
+    } catch (error) {
+      console.error(error);
+      setStatus(error instanceof Error ? error.message : 'タグの取得に失敗しました', 'error');
+      elements.tbody.innerHTML = '';
+      elements.empty.hidden = false;
+    } finally {
+      state.loading = false;
+      elements.reloadButton.disabled = false;
+    }
+  }
+
+  function setupEvents(): void {
+    elements.searchInput.addEventListener('input', () => {
+      state.filter = elements.searchInput.value;
+      render();
+    });
+    elements.reloadButton.addEventListener('click', () => {
+      loadTags().catch(error => {
+        console.error(error);
+        setStatus('タグの再読み込みに失敗しました', 'error');
+      });
+    });
+  }
+
+  setupEvents();
+  loadTags().catch(error => {
+    console.error(error);
+    setStatus('タグの初期読込に失敗しました', 'error');
+  });
+})();

--- a/tag-manager.html
+++ b/tag-manager.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' file: data:;" />
+    <title>タグ編集 - NyanTaskNotes</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 24px; color: #222; }
+      h1 { margin-bottom: 16px; }
+      .controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-bottom: 16px; }
+      .controls label { font-weight: 600; font-size: 13px; color: #444; }
+      .controls input[type="text"] { padding: 6px 8px; font-size: 14px; min-width: 220px; }
+      .controls button { padding: 8px 12px; font-size: 14px; cursor: pointer; }
+      .status { font-size: 13px; color: #555; }
+      .status[data-kind="error"] { color: #c0392b; }
+      .status[data-kind="success"] { color: #2c7a7b; }
+      table { width: 100%; border-collapse: collapse; margin-bottom: 8px; }
+      thead { background: #f5f5f5; }
+      th, td { padding: 8px 12px; border-bottom: 1px solid #ddd; font-size: 14px; text-align: left; }
+      th.col-actions, td.col-actions { text-align: right; }
+      td.col-name span { font-weight: 600; }
+      td.col-actions button { padding: 6px 10px; font-size: 13px; }
+      .empty { color: #777; margin-top: 12px; }
+      @media (max-width: 640px) {
+        table, thead, tbody, th, td, tr { display: block; }
+        thead { display: none; }
+        tr { border: 1px solid #ddd; border-radius: 6px; margin-bottom: 12px; padding: 8px; }
+        td { border: none; padding: 6px 0; }
+        td.col-actions { text-align: left; }
+        td.col-name span { display: inline-block; margin-bottom: 4px; }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>タグ編集</h1>
+    <div class="controls">
+      <label for="searchInput">検索</label>
+      <input id="searchInput" type="text" placeholder="タグ名を入力" autocomplete="off" />
+      <button id="reloadButton" type="button">再読込</button>
+      <span id="statusMessage" class="status" data-kind="info">読み込み待機中...</span>
+    </div>
+    <table aria-label="タグ一覧">
+      <thead>
+        <tr>
+          <th class="col-id">ID</th>
+          <th class="col-name">タグ名</th>
+          <th class="col-updated">更新日時</th>
+          <th class="col-actions">操作</th>
+        </tr>
+      </thead>
+      <tbody id="tagTableBody"></tbody>
+    </table>
+    <div id="emptyState" class="empty" hidden>タグがありません</div>
+    <script src="js/tagManager.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
  概要

  - TAG_INFOSを一覧・検索し、名前変更できるElectron画面を追加
  - タグメタ情報取得と名前更新のIPC/APIを実装し、重複チェックや更新日時を適正化
  - アプリメニューに「タグ編集」を追加して新画面へ遷移可能に

  確認手順

  1. npm install（未実施の場合）
  2. npm run build
  3. npm start
  4. メニューから「タグ編集」を開き、任意のタグ名を変更してリストに反映されることを確認