### PR TITLE
feat: タスク延期ダイアログの刷新と期限超過判定の改善

### DIFF
--- a/src/renderer/taskViewer.ts
+++ b/src/renderer/taskViewer.ts
@@ -239,7 +239,7 @@ async function loadTasks(): Promise<void> {
 
   type Bucket = { key: string; label: string; order: number };
   const buckets: Bucket[] = [
-    { key: 'overdueOnce', label: '期限超過（単発）', order: 0 },
+    { key: 'overdueOnce', label: '期限超過', order: 0 },
     { key: 'pastOrToday', label: '今日', order: 1 },
     { key: 'tomorrow', label: '明日', order: 2 },
     { key: 'byWeekend', label: '週末まで', order: 3 },
@@ -269,18 +269,16 @@ async function loadTasks(): Promise<void> {
     }
     (o as any).__overdueDays = undefined;
     (o as any).__overdueDueDate = undefined;
-    const isSingleTask = Number(o.IS_RECURRING || 0) === 0;
-    if (isSingleTask) {
-      const dueBase = formatDateInput((o as any).DUE_AT) || formatDateInput(o.SCHEDULED_DATE) || effectiveDateStr;
-      if (dueBase) {
-        const dueDate = toDate(dueBase);
-        const overdueDays = Math.floor((todayStart.getTime() - dueDate.getTime()) / MS_PER_DAY);
-        if (overdueDays > 0) {
-          (o as any).__overdueDays = overdueDays;
-          (o as any).__overdueDueDate = dueBase;
-          groups.get('overdueOnce')!.push(o);
-          continue;
-        }
+    const deferredDateStr = formatDateInput(o.DEFERRED_DATE);
+    const dueBase = deferredDateStr || formatDateInput((o as any).DUE_AT) || formatDateInput(o.SCHEDULED_DATE) || effectiveDateStr;
+    if (o.OCC_STATUS !== 'done' && dueBase) {
+      const dueDate = toDate(dueBase);
+      const overdueDays = Math.floor((todayStart.getTime() - dueDate.getTime()) / MS_PER_DAY);
+      if (overdueDays > 0) {
+        (o as any).__overdueDays = overdueDays;
+        (o as any).__overdueDueDate = dueBase;
+        groups.get('overdueOnce')!.push(o);
+        continue;
       }
     }
     let key: string;

--- a/task-view.html
+++ b/task-view.html
@@ -30,6 +30,17 @@
       .tag-filter-chip-row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
       .tag-filter-actions { display: flex; gap: 8px; margin-top: 8px; }
       .tag-filter-actions button { padding: 4px 10px; font-size: 12px; }
+      dialog.defer-dialog { border: none; border-radius: 12px; padding: 18px 20px; width: min(320px, 92vw); box-shadow: 0 18px 40px rgba(0, 0, 0, 0.2); background: #fff; color: #333; }
+      dialog.defer-dialog::backdrop { background: rgba(0, 0, 0, 0.35); }
+      .defer-dialog-form { display: flex; flex-direction: column; gap: 12px; }
+      .defer-dialog-title { font-size: 16px; font-weight: 600; }
+      .defer-dialog-description { font-size: 13px; color: #555; margin: -4px 0 0; }
+      .defer-dialog-field { display: flex; flex-direction: column; gap: 6px; font-size: 13px; }
+      .defer-dialog-field label { font-weight: 600; }
+      .defer-dialog-field input[type="date"] { padding: 6px 8px; font-size: 14px; }
+      .defer-dialog-note { font-size: 12px; color: #666; }
+      .defer-dialog-buttons { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
+      .defer-dialog-buttons button { padding: 6px 12px; }
     </style>
   </head>
   <body>


### PR DESCRIPTION
  - タイトル: feat: タスク延期ダイアログの刷新と期限超過判定の改善
  - 概要:
      - タスク延期ダイアログをカレンダー入力ベースに刷新し、日付選択を直感的に。
      - 延期後の予定日時を期限超過判定に反映し、表示の齟齬を解消。
  - 確認方法:
      1. npm install
      2. npm run dev
      3. 延期ボタンからダイアログを開き、カレンダー操作で日付と時間を変更できることを確認。
      4. 延期後のタスクで期限超過表示が正しく更新されることを確認。