### PR TITLE
feat: 期限超過タスクに完了日指定ボタンを追加

### DIFF
--- a/src/ipc/taskHandlers.ts
+++ b/src/ipc/taskHandlers.ts
@@ -103,7 +103,7 @@ export function registerTaskIpcHandlers(opts: {
     }
   });
 
-  ipcMain.handle('occ:complete', async (_event, id: number, options?: { comment?: string }) => {
+  ipcMain.handle('occ:complete', async (_event, id: number, options?: { comment?: string; completedAt?: string }) => {
     const db = getTaskDb();
     if (!db) return { success: false };
     try {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -25,7 +25,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   ,
   // Occurrences
   listOccurrences: (params?: any) => ipcRenderer.invoke('occ:list', params || {}),
-  completeOccurrence: (id: number, options?: { comment?: string }) => ipcRenderer.invoke('occ:complete', id, options || {}),
+  completeOccurrence: (id: number, options?: { comment?: string; completedAt?: string }) => ipcRenderer.invoke('occ:complete', id, options || {}),
   deferOccurrence: (id: number, newDate?: string | null) => ipcRenderer.invoke('occ:defer', id, newDate ?? null)
   ,
   // Task tags
@@ -58,7 +58,7 @@ declare global {
       updateTask: (id: number, payload: any) => Promise<{ success: boolean }>;
       deleteTask: (id: number) => Promise<{ success: boolean }>;
       listOccurrences: (params?: any) => Promise<any[]>;
-      completeOccurrence: (id: number, options?: { comment?: string }) => Promise<{ success: boolean }>;
+      completeOccurrence: (id: number, options?: { comment?: string; completedAt?: string }) => Promise<{ success: boolean }>;
       deferOccurrence: (id: number, newDate?: string | null) => Promise<{ success: boolean }>;
       listTaskTags: () => Promise<string[]>;
       listTaskTagInfos: () => Promise<Array<{ id: number; name: string; createdAt: string | null; updatedAt: string | null }>>;


### PR DESCRIPTION
  本文案

  ## 概要

  - 期限超過タスク向けに「日付を指定して完了にする」ダイアログを追加し、期日〜本日までの範囲で完了日を指定可能にした
  - 指定した完了日時を IPC/DB 層で受け取り保存し、完了基準の日次タスクは指定日時から次回発生日を算出するよう調整した
  - 完了コメント必須タスクにも対応しつつ、入力バリデーション結果をユーザーに通知するようにした

  ## 動作確認

  - npm run build