### PR TITLE
 feat: 完了後に次期日を指定する繰り返しタスクの実装

### DIFF
--- a/db/task_schema.sql
+++ b/db/task_schema.sql
@@ -39,6 +39,8 @@ CREATE TABLE IF NOT EXISTS "RECURRENCE_RULES" (
   "END_KIND" TEXT NOT NULL DEFAULT 'none' CHECK("END_KIND" IN ('none','until','count')),
   "UNTIL_DATE" TEXT,
   "COUNT" INTEGER,
+  -- 完了時に次期日を手動指定するモード
+  "MANUAL_NEXT_DUE" INTEGER NOT NULL DEFAULT 0,
   -- 日次の生成ウィンドウ（日数）。daily のみで使用。既定14日。
   "HORIZON_DAYS" INTEGER DEFAULT 14,
   -- 週次用: 曜日ビットマスク（bit0=日〜bit6=土）

--- a/src/ipc/taskHandlers.ts
+++ b/src/ipc/taskHandlers.ts
@@ -103,7 +103,7 @@ export function registerTaskIpcHandlers(opts: {
     }
   });
 
-  ipcMain.handle('occ:complete', async (_event, id: number, options?: { comment?: string; completedAt?: string }) => {
+  ipcMain.handle('occ:complete', async (_event, id: number, options?: { comment?: string; completedAt?: string; manualNextDue?: string }) => {
     const db = getTaskDb();
     if (!db) return { success: false };
     try {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -30,7 +30,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   ,
   // Occurrences
   listOccurrences: (params?: any) => ipcRenderer.invoke('occ:list', params || {}),
-  completeOccurrence: (id: number, options?: { comment?: string; completedAt?: string }) => ipcRenderer.invoke('occ:complete', id, options || {}),
+  completeOccurrence: (id: number, options?: { comment?: string; completedAt?: string; manualNextDue?: string }) => ipcRenderer.invoke('occ:complete', id, options || {}),
   deferOccurrence: (id: number, newDate?: string | null) => ipcRenderer.invoke('occ:defer', id, newDate ?? null)
   ,
   // Task tags
@@ -66,7 +66,7 @@ declare global {
       updateTask: (id: number, payload: any) => Promise<{ success: boolean }>;
       deleteTask: (id: number) => Promise<{ success: boolean }>;
       listOccurrences: (params?: any) => Promise<any[]>;
-      completeOccurrence: (id: number, options?: { comment?: string; completedAt?: string }) => Promise<{ success: boolean }>;
+      completeOccurrence: (id: number, options?: { comment?: string; completedAt?: string; manualNextDue?: string }) => Promise<{ success: boolean }>;
       deferOccurrence: (id: number, newDate?: string | null) => Promise<{ success: boolean }>;
       listTaskTags: () => Promise<string[]>;
       listTaskTagInfos: () => Promise<Array<{ id: number; name: string; createdAt: string | null; updatedAt: string | null }>>;

--- a/src/renderer/sharedTaskEditor.ts
+++ b/src/renderer/sharedTaskEditor.ts
@@ -20,6 +20,7 @@ export type TaskRow = {
   COUNT?: number | null;
   HORIZON_DAYS?: number | null;
   WEEKLY_DOWS?: number | null;
+  MANUAL_NEXT_DUE?: number | null;
 };
 
 export type RecurrenceUIMode =
@@ -30,7 +31,8 @@ export type RecurrenceUIMode =
   | 'weekly'
   | 'monthly'
   | 'monthlyNth'
-  | 'yearly';
+  | 'yearly'
+  | 'manualNext';
 
 export function formatDateInput(dateStr?: string | null): string {
   if (!dateStr) return '';
@@ -46,6 +48,7 @@ export function formatDateInput(dateStr?: string | null): string {
 // DBの行からUIモードを推定
 export function inferRecurrenceModeFromDb(t: TaskRow): RecurrenceUIMode {
   if (!t.IS_RECURRING) return 'once';
+  if (Number((t as any).MANUAL_NEXT_DUE || 0) === 1) return 'manualNext';
   if (t.FREQ === 'monthly') {
     if ((t as any).MONTHLY_NTH !== null && typeof (t as any).MONTHLY_NTH !== 'undefined') return 'monthlyNth';
     return 'monthly';
@@ -77,4 +80,3 @@ export function weeklyArrayFromMask(mask: number): number[] {
   for (let i = 0; i <= 6; i++) if (mask & (1 << i)) out.push(i);
   return out;
 }
-

--- a/src/renderer/taskSettings.ts
+++ b/src/renderer/taskSettings.ts
@@ -18,6 +18,7 @@
     COUNT?: number | null;
     HORIZON_DAYS?: number | null;
     WEEKLY_DOWS?: number | null;
+    MANUAL_NEXT_DUE?: number | null;
     REQUIRE_COMPLETE_COMMENT?: number | null;
   };
 
@@ -76,6 +77,7 @@
 
   function getRecurrenceCategory(task: TaskRow): string {
     if (!task.IS_RECURRING) return 'once';
+    if (Number(task.MANUAL_NEXT_DUE || 0) === 1) return 'manualNext';
     const freq = (task.FREQ || '').toLowerCase();
     if (freq === 'daily') {
       const anchor = (task.INTERVAL_ANCHOR || 'scheduled').toLowerCase();
@@ -95,6 +97,9 @@
     const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
     const freq = (task.FREQ || '').toLowerCase();
     if (!task.IS_RECURRING) return '単発';
+    if (Number(task.MANUAL_NEXT_DUE || 0) === 1) {
+      return '完了時に期日を指定';
+    }
     if (freq === 'daily') {
       const interval = Number(task.INTERVAL || 1);
       const anchor = (task.INTERVAL_ANCHOR || 'scheduled');

--- a/task-editor2.html
+++ b/task-editor2.html
@@ -83,6 +83,7 @@
           <div class="row"><label for="isRecurring">繰り返し</label>
             <select id="isRecurring">
               <option value="once">１回のみ</option>
+              <option value="manualNext">完了後に次の期日を指定</option>
               <option value="daily">毎日</option>
               <option value="everyNScheduled">指定日数ごと（前回発生した日付から）</option>
               <option value="everyNCompleted">指定日数ごと（前回完了した日付から）</option>

--- a/task-settings.html
+++ b/task-settings.html
@@ -43,6 +43,7 @@
         <select id="recurrenceSelect">
           <option value="all">すべて</option>
           <option value="once">単発（1回のみ）</option>
+          <option value="manualNext">手動（完了時に次期日指定）</option>
           <option value="dailyScheduled">毎日 / 予定基準</option>
           <option value="dailyCompleted">毎日 / 完了基準</option>
           <option value="weekly">毎週</option>


### PR DESCRIPTION
  - manual-next 用の MANUAL_NEXT_DUE フラグを追加し、DB・IPC・renderer へ伝播
  - タスク編集画面に「完了後に次の期日を指定」オプションを追加し、初回完了までは単発同様に扱うよう調整
  - タスク表示画面の完了ダイアログを拡張し、手動タスクでは次期日の入力を必須化

  確認手順

  1. npm run build
  2. タスク編集画面で新しい繰り返し種別を選び、期日・完了動作を確認
  3. タスク表示画面で完了ダイアログに次期日入力が要求されることを確認